### PR TITLE
fix: unwrap panic with more info

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,11 +260,11 @@ impl<C: Borrow<rcgen::CertifiedKey> + Send + Sync + 'static> MitmProxy<C> {
                                 if uri.authority() == Some(&connect_authority) {
                                     send_request_connect.send_request(req).await
                                 } else {
-                                    let mut sender = proxy.connect(req.uri()).await.unwrap();
+                                    let mut sender = proxy.connect(req.uri()).await.expect(&format!("connect uri: {}", req.uri()));
                                     sender.send_request(req).await
                                 }
                             } else {
-                                let mut sender = proxy.connect(req.uri()).await.unwrap();
+                                let mut sender = proxy.connect(req.uri()).await.expect(&format!("connect uri: {}", req.uri()));
                                 sender.send_request(req).await
                             };
 
@@ -342,7 +342,7 @@ impl<C: Borrow<rcgen::CertifiedKey> + Send + Sync + 'static> MitmProxy<C> {
             ))
         } else {
             let uri = req.uri().clone();
-            let mut sender = proxy.connect(req.uri()).await.unwrap();
+            let mut sender = proxy.connect(req.uri()).await.expect(&format!("connect uri: {}", req.uri()));
 
             let (req, req_parts) = dup_request(req);
             let (status, res, res_upgrade) = match sender.send_request(req).await {


### PR DESCRIPTION
fix: #34 

The panic info will be printed as below:


> thread 'tokio-runtime-worker' panicked at /Users/my/.cargo/registry/src/index.crates.io-6f17d22bba15001f/http-mitm-proxy-0.7.1/src/lib.rs:267:81:
> **connect uri: https://www2.bing.com:443/ipv6test/test: handshake failure**
> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
